### PR TITLE
Update to use unsigned int instead of char

### DIFF
--- a/SimpleFIFO.h
+++ b/SimpleFIFO.h
@@ -47,14 +47,14 @@ public:
 
 private:
 #ifndef SimpleFIFO_NONVOLATILE
-	volatile char numberOfElements;
-	volatile char nextIn;
-	volatile char nextOut;
+	volatile unsigned int numberOfElements;
+	volatile unsigned int nextIn;
+	volatile unsigned int nextOut;
 	volatile T raw[rawSize];
 #else
-	char numberOfElements;
-	char nextIn;
-	char nextOut;
+	unsigned int numberOfElements;
+	unsigned int nextIn;
+	unsigned int nextOut;
 	T raw[rawSize];
 #endif
 };


### PR DESCRIPTION
This update will allow for fifos larger than 127 elements. Thanks to charleslaub at sbcglobal dot net for getting in touch. Also, thank you for maintaining a version of this for Arduino. For those interested, FIFO and LIFO is a standard library for the Wiring project: http://wiring.co
